### PR TITLE
fix: correct handling of bbb-client custom parameters

### DIFF
--- a/src/videoConfProvider.ts
+++ b/src/videoConfProvider.ts
@@ -309,7 +309,7 @@ export class BBBProvider implements IVideoConfProvider {
 		if (method === 'join') {
 			Object.keys(this.app.additionalParams)
 				.filter((key) => key.startsWith('userdata-bbb'))
-				.forEach((key) => paramList.push(this.app.additionalParams[key]));
+				.forEach((key) => paramList.push(`${this.encodeForUrl(key)}=${this.encodeForUrl(this.app.additionalParams[key])}`));
 		}
 
 		const query = paramList.join('&');


### PR DESCRIPTION
### Description
This PR fixes the incorrect handling of bbb-client custom parameters. Users can now provide a custom parameters json in the following format
```json
{
  "userdata-bbb_client_title": "Custom Meeting Titile" 
}
```
#### Issue
The custom parameter for `bbb-client` expects a JSON with keys that start with `userdata-bbb_`. However, the value was not being correctly taken into account. An expected valid entry like `{ "userdata-bbb_client_title": "test+custom" }` did not work. Instead, to make it work, the input had to be `{ "userdata-bbb_client_title": "userdata-bbb_client_title=test+custom" }`.

[SUP-585](https://rocketchat.atlassian.net/browse/SUP-585)

[SUP-585]: https://rocketchat.atlassian.net/browse/SUP-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ